### PR TITLE
fix: Modify default max bytes to 1.85 MB

### DIFF
--- a/crates/evolve/src/config.rs
+++ b/crates/evolve/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-/// Default maximum bytes for txpool transactions (1.85 MB)
-pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = (1.85 * 1024.0 * 1024.0) as u64; // 1.85 MB = 1,939,866 bytes
+/// Default maximum bytes for txpool transactions (1.85 MiB)
+pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = (1.85 * 1024.0 * 1024.0).round() as u64; // 1.85 MiB = 1,939,866 bytes
 
 /// Configuration for Rollkit-specific functionality
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/evolve/src/config.rs
+++ b/crates/evolve/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Default maximum bytes for txpool transactions (1.85 MiB)
-pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = 1_939_866; // 1.85 MiB = 1,939,866 bytes
+pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = 1_939_865; // 1.85 MiB = 1,939,865 bytes
 
 /// Configuration for Rollkit-specific functionality
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/evolve/src/config.rs
+++ b/crates/evolve/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-/// Default maximum bytes for txpool transactions (1.98 MB)
-pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = 1_980 * 1024; // 1.98 MB = 2,027,520 bytes
+/// Default maximum bytes for txpool transactions (1.85 MB)
+pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = (1.85 * 1024.0 * 1024.0) as u64; // 1.85 MB = 1,939,866 bytes
 
 /// Configuration for Rollkit-specific functionality
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/evolve/src/config.rs
+++ b/crates/evolve/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Default maximum bytes for txpool transactions (1.85 MiB)
-pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = (1.85 * 1024.0 * 1024.0).round() as u64; // 1.85 MiB = 1,939,866 bytes
+pub const DEFAULT_MAX_TXPOOL_BYTES: u64 = 1_939_866; // 1.85 MiB = 1,939,866 bytes
 
 /// Configuration for Rollkit-specific functionality
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/evolve/src/rpc/txpool.rs
+++ b/crates/evolve/src/rpc/txpool.rs
@@ -85,7 +85,7 @@ mod tests {
         // Test that the default max_txpool_bytes value is correctly set
         let config = RollkitConfig::default();
         assert_eq!(config.max_txpool_bytes, DEFAULT_MAX_TXPOOL_BYTES);
-        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, (1.85 * 1024.0 * 1024.0) as u64); // 1.85 MB
+        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, 1_939_866); // 1.85 MiB
     }
 
     #[test]

--- a/crates/evolve/src/rpc/txpool.rs
+++ b/crates/evolve/src/rpc/txpool.rs
@@ -85,7 +85,7 @@ mod tests {
         // Test that the default max_txpool_bytes value is correctly set
         let config = RollkitConfig::default();
         assert_eq!(config.max_txpool_bytes, DEFAULT_MAX_TXPOOL_BYTES);
-        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, 1_980 * 1024); // 1.98 MB
+        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, (1.85 * 1024.0 * 1024.0) as u64); // 1.85 MB
     }
 
     #[test]
@@ -95,7 +95,7 @@ mod tests {
 
         // Test with default config
         let config = RollkitConfig::default();
-        assert_eq!(config.max_txpool_bytes, 1_980 * 1024);
+        assert_eq!(config.max_txpool_bytes, (1.85 * 1024.0 * 1024.0) as u64);
 
         // Test with custom config
         let custom_config = RollkitConfig::new(1000);

--- a/crates/evolve/src/rpc/txpool.rs
+++ b/crates/evolve/src/rpc/txpool.rs
@@ -85,7 +85,7 @@ mod tests {
         // Test that the default max_txpool_bytes value is correctly set
         let config = RollkitConfig::default();
         assert_eq!(config.max_txpool_bytes, DEFAULT_MAX_TXPOOL_BYTES);
-        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, 1_939_866); // 1.85 MiB
+        assert_eq!(DEFAULT_MAX_TXPOOL_BYTES, 1_939_865); // 1.85 MiB
     }
 
     #[test]
@@ -95,7 +95,7 @@ mod tests {
 
         // Test with default config
         let config = RollkitConfig::default();
-        assert_eq!(config.max_txpool_bytes, (1.85 * 1024.0 * 1024.0) as u64);
+        assert_eq!(config.max_txpool_bytes, 1_939_865); // 1.85 MiB
 
         // Test with custom config
         let custom_config = RollkitConfig::new(1000);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. -->

The default max tx size in celestia is about 1.88 MB as per https://docs.celestia.org/how-to-guides/submit-data#maximum-blob-size (1973786/(1024*1024) ~ 1.882). This PR modifies the max bytes the set of transactions can be from 1.98 MB to 1.85 MB which provides a bit of buffer for other data structures for evolve node during DA submission.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues

<!-- Link to any related issues -->
Fixes #(issue)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->