### PR TITLE
chore: add curl to docker image

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -9,6 +9,8 @@ ARG BUILDPLATFORM
 # Copy the pre-built binary based on the target platform
 COPY dist/bin/${TARGETPLATFORM}/ev-reth /usr/local/bin/ev-reth
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 # Expose default ports
 EXPOSE 8545 8546 30303 6060 9001
 


### PR DESCRIPTION
The change adds the curl utility to the cross-platform Docker image, which is commonly needed for health checks, debugging, or making HTTP requests from within the container.