### PR TITLE
chore: add jq to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN cp /app/target/$BUILD_PROFILE/ev-reth /ev-reth
 FROM ubuntu:22.04 AS runtime
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl libssl-dev pkg-config strace && \
+    apt-get install -y ca-certificates curl jq libssl-dev pkg-config strace && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -9,7 +9,7 @@ ARG BUILDPLATFORM
 # Copy the pre-built binary based on the target platform
 COPY dist/bin/${TARGETPLATFORM}/ev-reth /usr/local/bin/ev-reth
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq && rm -rf /var/lib/apt/lists/*
 
 # Expose default ports
 EXPOSE 8545 8546 30303 6060 9001

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -4,6 +4,7 @@ FROM ghcr.io/cross-rs/cross:main
 RUN apt-get update && \
     apt-get install -y \
         curl \
+        jq \
         gcc-aarch64-linux-gnu \
         g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross \

--- a/Dockerfile.cross-x86_64
+++ b/Dockerfile.cross-x86_64
@@ -5,6 +5,7 @@ RUN apt-get update && \
     apt-get install -y \
         build-essential \
         curl \
+        jq \
         pkg-config \
         libclang-dev \
         clang && \


### PR DESCRIPTION
The change adds the jq utility to the Docker images, to allow entrypoints to easily parse json for automated deployments.