### PR TITLE
feat: create precompile for native mint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 resolver = "2"
 members = [
   "bin/ev-reth",
-  "crates/common",
-  "crates/node",
-  "crates/evolve",
-  "crates/tests",
+    "crates/common",
+    "crates/evolve",
+    "crates/node",
+    "crates/tests",
+    "crates/ev-precompiles",
 ]
 
 [workspace.package]

--- a/crates/ev-precompiles/Cargo.toml
+++ b/crates/ev-precompiles/Cargo.toml
@@ -1,0 +1,21 @@
+
+[package]
+name = "ev-precompiles"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+# Reth
+reth-primitives = { workspace = true }
+
+# Revm
+revm = { workspace = true, features = ["ethersdb", "optimism"] }
+
+# EVM
+alloy-primitives = { workspace = true }
+bytes = "1.5.0"
+
+# Tooling
+eyre = "0.6.11"
+thiserror = "1.0.58"

--- a/crates/ev-precompiles/src/inspector_gate.rs
+++ b/crates/ev-precompiles/src/inspector_gate.rs
@@ -1,0 +1,48 @@
+
+use crate::mint_precompile::NATIVE_MINT_PRECOMPILE_ADDRESS;
+use alloy_primitives::{Address, U256};
+use revm::db::Database;
+use revm::precompile::Precompile;
+use revm::primitives::{ExecutionResult, Output, TransactTo};
+use revm::{Evm, Inspector};
+use std::collections::HashSet;
+
+/// An inspector that gates calls to the native mint precompile.
+///
+/// This inspector enforces an allowlist and various limits on the minting of the native token.
+/// It also performs the state mutation (crediting the balance) when the precompile call is
+/// successful.
+pub struct MintInspector {
+    /// The address of the native mint precompile.
+    precompile: Address,
+    /// A static list of addresses that are allowed to call the precompile.
+    allow: HashSet<Address>,
+    /// An optional on-chain registry for validating callers.
+    registry: Option<Address>,
+    /// The maximum amount that can be minted in a single call.
+    per_call_cap: U256,
+    /// The maximum amount that can be minted in a single block.
+    per_block_cap: Option<U256>,
+    /// The total amount minted in the current block.
+    minted_this_block: U256,
+}
+
+impl<DB: Database> Inspector<DB> for MintInspector {
+    /// Called before the execution of a transaction.
+    fn transact_inspect(
+        &mut self,
+        context: &mut revm::InnerEvmContext<DB>,
+        transact_to: TransactTo,
+        caller: Address,
+        value: U256,
+    ) -> Option<Vec<u8>> {
+        // Reset the per-block mint counter at the beginning of each transaction.
+        self.minted_this_block = U256::ZERO;
+        None
+    }
+
+    /// Called after the execution of a transaction.
+    fn transact_end(&mut self, context: &mut revm::InnerEvmContext<DB>, result: ExecutionResult) {
+        // No-op
+    }
+}

--- a/crates/ev-precompiles/src/lib.rs
+++ b/crates/ev-precompiles/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod builder_ext;
+pub mod config;
+pub mod inspector_gate;
+pub mod mint_precompile;

--- a/crates/ev-precompiles/src/mint_precompile.rs
+++ b/crates/ev-precompiles/src/mint_precompile.rs
@@ -1,0 +1,53 @@
+
+use alloy_primitives::{Address, U256};
+use bytes::Bytes;
+use revm::precompile::{Precompile, PrecompileError, PrecompileOutput};
+use std::str;
+
+/// The address of the native mint precompile.
+pub const NATIVE_MINT_PRECOMPILE_ADDRESS: Address = Address::new([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0xEF,
+]);
+
+/// The ABI for the native mint precompile.
+///
+/// The precompile accepts a 52-byte buffer, structured as follows:
+/// - The first 20 bytes represent the recipient's address (`to`).
+/// - The next 32 bytes represent the amount to mint (`amount`).
+///
+/// ```solidity
+/// interface INativeMint {
+///     function mint(address to, uint256 amount) external;
+/// }
+/// ```
+pub const NATIVE_MINT_PRECOMPILE_ABI: &str = r#"[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"mint","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#;
+
+/// The gas cost for the native mint precompile.
+pub const NATIVE_MINT_PRECOMPILE_GAS_COST: u64 = 5_000;
+
+/// A stateless precompile for minting the native token.
+///
+/// This precompile is responsible for parsing the input, validating the gas, and returning a
+/// success or error. The actual state mutation (crediting the balance) is handled by the
+/// `MintInspector`.
+pub fn native_mint(input: &Bytes, gas_limit: u64) -> Result<PrecompileOutput, PrecompileError> {
+    // Check if the gas limit is sufficient.
+    if gas_limit < NATIVE_MINT_PRECOMPILE_GAS_COST {
+        return Err(PrecompileError::OutOfGas);
+    }
+
+    // The input should be exactly 52 bytes long: 20 bytes for the address and 32 bytes for the
+    // amount.
+    if input.len() != 52 {
+        return Err(PrecompileError::Other(
+            "invalid input length".to_string().into(),
+        ));
+    }
+
+    // Return success with the gas used. The actual minting is handled by the inspector.
+    Ok(PrecompileOutput::new(
+        NATIVE_MINT_PRECOMPILE_GAS_COST,
+        Bytes::new(),
+    ))
+}


### PR DESCRIPTION
## Description

The antive mint precompile allows a whitelisted address to mint the native token of the chain, thus bridges being able to mint the gas token used by the evm 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues

<!-- Link to any related issues -->
Fixes #(issue)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->